### PR TITLE
Update all spring boot pom.xml versions to 2.1.2

### DIFF
--- a/Lesson 1-The Spring Project and Framework/Activity/blogmania/pom.xml
+++ b/Lesson 1-The Spring Project and Framework/Activity/blogmania/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 1-The Spring Project and Framework/Topic B/blogmania/pom.xml
+++ b/Lesson 1-The Spring Project and Framework/Topic B/blogmania/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 1-The Spring Project and Framework/Topic C/blogmania/pom.xml
+++ b/Lesson 1-The Spring Project and Framework/Topic C/blogmania/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 2-Building a Spring Application/Topic A/blogmania-exercise-solution/pom.xml
+++ b/Lesson 2-Building a Spring Application/Topic A/blogmania-exercise-solution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 2-Building a Spring Application/Topic A/blogmania/pom.xml
+++ b/Lesson 2-Building a Spring Application/Topic A/blogmania/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 2-Building a Spring Application/Topic B/blogmania-exercise-solution/pom.xml
+++ b/Lesson 2-Building a Spring Application/Topic B/blogmania-exercise-solution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 2-Building a Spring Application/Topic B/blogmania/pom.xml
+++ b/Lesson 2-Building a Spring Application/Topic B/blogmania/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 3-Testing Spring Applications/Topic A/blogmania/pom.xml
+++ b/Lesson 3-Testing Spring Applications/Topic A/blogmania/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 3-Testing Spring Applications/Topic B/blogmania/pom.xml
+++ b/Lesson 3-Testing Spring Applications/Topic B/blogmania/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 4-The MVC Pattern/activity-blog-setup/pom.xml
+++ b/Lesson 4-The MVC Pattern/activity-blog-setup/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 4-The MVC Pattern/exercise-static-assets/pom.xml
+++ b/Lesson 4-The MVC Pattern/exercise-static-assets/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 4-The MVC Pattern/exercise-webstarter/pom.xml
+++ b/Lesson 4-The MVC Pattern/exercise-webstarter/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 4-The MVC Pattern/handler-mapping/pom.xml
+++ b/Lesson 4-The MVC Pattern/handler-mapping/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 5-Display Information Using Web Pages/activity-thymeleaf/pom.xml
+++ b/Lesson 5-Display Information Using Web Pages/activity-thymeleaf/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 5-Display Information Using Web Pages/basic-thymeleaf/pom.xml
+++ b/Lesson 5-Display Information Using Web Pages/basic-thymeleaf/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 5-Display Information Using Web Pages/exercise-basic-thymeleaf/pom.xml
+++ b/Lesson 5-Display Information Using Web Pages/exercise-basic-thymeleaf/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 5-Display Information Using Web Pages/exercise-first-thymeleaf/pom.xml
+++ b/Lesson 5-Display Information Using Web Pages/exercise-first-thymeleaf/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 6-Pass Data between View and Controller/activity/blogmania/pom.xml
+++ b/Lesson 6-Pass Data between View and Controller/activity/blogmania/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 6-Pass Data between View and Controller/exercises/form-handling/pom.xml
+++ b/Lesson 6-Pass Data between View and Controller/exercises/form-handling/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 6-Pass Data between View and Controller/exercises/input-types-and-value-binding/pom.xml
+++ b/Lesson 6-Pass Data between View and Controller/exercises/input-types-and-value-binding/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 6-Pass Data between View and Controller/input-types-and-value-binding/pom.xml
+++ b/Lesson 6-Pass Data between View and Controller/input-types-and-value-binding/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 6-Pass Data between View and Controller/solutions/blogmania/pom.xml
+++ b/Lesson 6-Pass Data between View and Controller/solutions/blogmania/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 6-Pass Data between View and Controller/solutions/form-handling/pom.xml
+++ b/Lesson 6-Pass Data between View and Controller/solutions/form-handling/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 6-Pass Data between View and Controller/solutions/input-types-and-value-binding/pom.xml
+++ b/Lesson 6-Pass Data between View and Controller/solutions/input-types-and-value-binding/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.2.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 

--- a/Lesson 7-RESTful APIs/activity/blogmania/pom.xml
+++ b/Lesson 7-RESTful APIs/activity/blogmania/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 7-RESTful APIs/exercises/hateoas-intro-after/pom.xml
+++ b/Lesson 7-RESTful APIs/exercises/hateoas-intro-after/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 7-RESTful APIs/hateoas-intro/pom.xml
+++ b/Lesson 7-RESTful APIs/hateoas-intro/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 7-RESTful APIs/rest-intro/pom.xml
+++ b/Lesson 7-RESTful APIs/rest-intro/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 8-Web Application Security/exercises/security-intro-before/pom.xml
+++ b/Lesson 8-Web Application Security/exercises/security-intro-before/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 8-Web Application Security/security-intro/pom.xml
+++ b/Lesson 8-Web Application Security/security-intro/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 9-Persist Data Using a Database/activity/database-activity-solution/pom.xml
+++ b/Lesson 9-Persist Data Using a Database/activity/database-activity-solution/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 9-Persist Data Using a Database/activity/database-activity/pom.xml
+++ b/Lesson 9-Persist Data Using a Database/activity/database-activity/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 9-Persist Data Using a Database/database-intro/pom.xml
+++ b/Lesson 9-Persist Data Using a Database/database-intro/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 9-Persist Data Using a Database/exercises/blogmania/pom.xml
+++ b/Lesson 9-Persist Data Using a Database/exercises/blogmania/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 

--- a/Lesson 9-Persist Data Using a Database/exercises/database-intro-flyway/pom.xml
+++ b/Lesson 9-Persist Data Using a Database/exercises/database-intro-flyway/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.3.RELEASE</version>
+        <version>2.1.2.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
This is the video author.  Version 2.0.x seems to have been deprecated on start.spring.io.  As of part-way into filming lessons 1 & 2 version 2.1.2 seems the most current.